### PR TITLE
Ray query

### DIFF
--- a/docs/using-the-compiler.md
+++ b/docs/using-the-compiler.md
@@ -531,3 +531,22 @@ The following new types are allowed when targetting Vulkan:
 - `:utexture-buffer`
 - `:utexture-cube`
 - `:utexture-cube-array`
+- `:acceleration-structure-ext` (only if `GL_EXT_ray_query` is enabled)
+- `:ray-query-ext` (only if `GL_EXT_ray_query` is enabled)
+
+#### Initializing rayQueryEXT instances (GL_EXT_ray_query extension)
+
+Unlike most types in GLSL, `rayQueryEXT` instances cannot by constructed by calling a GLSL function.
+They are usually declared only in a function's scope and initialized by a call to `rayQueryInitializeEXT`:
+
+    void main() {
+        rayQueryEXT q;
+        rayQueryInitializeEXT(q, ...);
+        ...
+    }
+
+To achieve the same in Vari, we define an uninitialized typed symbol (e.g. using `let`) and the proceed as we normally would:
+
+    (let (((q :ray-query-ext)))
+      (ray-query-initialize-ext q ...))
+

--- a/package.lisp
+++ b/package.lisp
@@ -280,6 +280,10 @@
            :v-utexture-rect
            :v-itexture-rect
            :v-texture-rect
+           ;;
+           :v-acceleration-structure-ext
+           ;;
+           :v-ray-query-ext
            ))
 
 ;;;; package.lisp

--- a/src/vari.glsl/parse-from-spec.lisp
+++ b/src/vari.glsl/parse-from-spec.lisp
@@ -2,7 +2,8 @@
 (in-readtable fn:fn-reader)
 
 (defparameter *glsl-type->varjo-type*
-  '(("atomic_uint" v-atomic-uint)
+  '(("accelerationStructureEXT" v-acceleration-structure-ext)
+    ("atomic_uint" v-atomic-uint)
     ("bool" v-bool)
     ("bufferImage" v-buffer-image)
     ("bvec2" v-bvec2)
@@ -90,6 +91,7 @@
     ("mat4x2" v-mat4x2)
     ("mat4x3" v-mat4x3)
     ("mat4x4" v-mat4x4)
+    ("rayQueryEXT" v-ray-query-ext)
     ("sampler" v-sampler-vulkan)
     ("sampler1D" v-sampler-1d)
     ("sampler1DArray" v-sampler-1d-array)

--- a/src/vari.types/types.lisp
+++ b/src/vari.types/types.lisp
@@ -1252,6 +1252,26 @@
                    :reader tertiary-score)))
 
 ;;----------------------------------------------------------------------
+;; accelerationStructureEXT (Vulkan only)
+
+(define-v-type-class v-acceleration-structure-ext (v-opaque-vulkan-type)
+  ((core :initform t :reader core-typep)
+   (glsl-string :initform "accelerationStructureEXT" :reader v-glsl-string)
+   (element-type :initform 'v-type)
+   (tertiary-score :initform 1 :initarg :tertiary-score
+                   :reader tertiary-score)))
+
+;;----------------------------------------------------------------------
+;; rayQueryEXT (Vulkan only)
+
+(define-v-type-class v-ray-query-ext (v-opaque-vulkan-type)
+  ((core :initform t :reader core-typep)
+   (glsl-string :initform "rayQueryEXT" :reader v-glsl-string)
+   (element-type :initform 'v-type)
+   (tertiary-score :initform 1 :initarg :tertiary-score
+                   :reader tertiary-score)))
+
+;;----------------------------------------------------------------------
 ;; Type Stubs
 ;;
 ;; {TODO} look into these

--- a/src/vari.types/types.lisp
+++ b/src/vari.types/types.lisp
@@ -1269,7 +1269,8 @@
    (glsl-string :initform "rayQueryEXT" :reader v-glsl-string)
    (element-type :initform 'v-type)
    (tertiary-score :initform 1 :initarg :tertiary-score
-                   :reader tertiary-score)))
+                   :reader tertiary-score)
+   (allow-unboundp :initform t :reader allow-unboundp)))
 
 ;;----------------------------------------------------------------------
 ;; Type Stubs

--- a/src/varjo.internals/compile-vars.lisp
+++ b/src/varjo.internals/compile-vars.lisp
@@ -41,7 +41,8 @@
 (defun compile-symbol (symbol env &key allow-unbound)
   (let ((binding (get-symbol-binding symbol t env)))
     (etypecase binding
-      (uninitialized-value (if allow-unbound
+      (uninitialized-value (if (or allow-unbound
+                                   (allow-unboundp (v-type-of binding)))
                                (v-variable->code-obj symbol binding env)
                                (error 'uninitialized-var :name symbol)))
       (v-symbol-macro (expand-symbol-macro binding env))

--- a/src/varjo.internals/globals.lisp
+++ b/src/varjo.internals/globals.lisp
@@ -365,7 +365,9 @@
     (:utexture-cube-array . v-utexture-cube-array)
     (:texture-rect . v-texture-rect)
     (:itexture-rect . v-itexture-rect)
-    (:utexture-rect . v-utexture-rect)))
+    (:utexture-rect . v-utexture-rect)
+    (:acceleration-structure-ext . v-acceleration-structure-ext)
+    (:ray-query-ext . v-ray-query-ext)))
 
 (defvar *base-reserved*
   '("active"
@@ -572,7 +574,8 @@
 
 ;;{TODO} add this to validation of glsl name strings when target is vulkan
 (defvar *reserved-vulkan*
-  '("isubpassInput"
+  '("accelerationStructureEXT"
+    "isubpassInput"
     "isubpassInputMS"
     "itexture1D"
     "itexture1DArray"
@@ -585,6 +588,7 @@
     "itextureBuffer"
     "itextureCube"
     "itextureCubeArray"
+    "rayQueryEXT"
     "sampler"
     "samplerShadow"
     "subpassInput"

--- a/src/varjo.internals/types/early-types.lisp
+++ b/src/varjo.internals/types/early-types.lisp
@@ -16,7 +16,8 @@
    (qualifiers :initform nil :initarg :qualifiers :reader qualifiers)
    (tertiary-score :initform 0 :initarg :tertiary-score
                    :reader tertiary-score)
-   (vulkan-onlyp :initform nil :reader vulkan-onlyp)))
+   (vulkan-onlyp :initform nil :reader vulkan-onlyp)
+   (allow-unboundp :initform nil :reader allow-unboundp)))
 
 ;;------------------------------------------------------------
 ;; Core type methods


### PR DESCRIPTION
Add types used in `rayQueryEXT`.

Add slot `allow-unboundp` to `v-type` for opaque types that aren't passed in as `uniform`s (e.g. `rayQueryEXT`).